### PR TITLE
Add Decoder JUnit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@ NICNAC16-SIM
 ============
 
 Software simulator implementing the evolving Instruction Set Architecture of my NICNAC16 design.
+
+Testing
+-------
+
+JUnit 4 tests reside under `src/test/java`. To run them you need the JUnit and
+Hamcrest libraries on the class path. The JUnit jars that ship with the Gradle
+installation on this environment can be used:
+
+```
+javac -d bin -cp /opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar \
+    src/de/czempin/nicnac16/*.java src/de/czempin/nicnac16/simulator/*.java \
+    src/test/java/de/czempin/nicnac16/simulator/DecoderTest.java
+java -cp bin:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar \
+    org.junit.runner.JUnitCore de.czempin.nicnac16.simulator.DecoderTest
+```
+
+Any IDE with JUnit support can run the tests as well.

--- a/src/test/java/de/czempin/nicnac16/simulator/DecoderTest.java
+++ b/src/test/java/de/czempin/nicnac16/simulator/DecoderTest.java
@@ -1,0 +1,55 @@
+package de.czempin.nicnac16.simulator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import de.czempin.nicnac16.Instruction;
+
+public class DecoderTest {
+
+    @Test
+    public void decodeNop() {
+        assertEquals(Instruction.NOP, Decoder.decode(0b0000));
+    }
+
+    @Test
+    public void decodeJmp() {
+        assertEquals(Instruction.JMP, Decoder.decode(0b0001));
+    }
+
+    @Test
+    public void decodeBl() {
+        assertEquals(Instruction.BL, Decoder.decode(0b0010));
+    }
+
+    @Test
+    public void decodeRet() {
+        assertEquals(Instruction.RET, Decoder.decode(0b0011));
+    }
+
+    @Test
+    public void decodeLda() {
+        assertEquals(Instruction.LDA, Decoder.decode(0b0100));
+    }
+
+    @Test
+    public void decodeSta() {
+        assertEquals(Instruction.STA, Decoder.decode(0b0101));
+    }
+
+    @Test
+    public void decodeAdd() {
+        assertEquals(Instruction.ADD, Decoder.decode(0b0110));
+    }
+
+    @Test
+    public void decodeBan() {
+        assertEquals(Instruction.BAN, Decoder.decode(0b1000));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void decodeInvalidThrows() {
+        Decoder.decode(0b1111);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for the opcode decoder
- document how to run the JUnit tests

## Testing
- `javac -d bin -cp /opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar src/de/czempin/nicnac16/*.java src/de/czempin/nicnac16/simulator/*.java src/test/java/de/czempin/nicnac16/simulator/DecoderTest.java`
- `java -cp bin:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore de.czempin.nicnac16.simulator.DecoderTest`