### PR TITLE
Add shell and batch scripts for building and testing

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal enabledelayedexpansion
+set BIN_DIR=bin
+set SRC_DIR=src
+set LIB_DIR=lib
+
+if not exist %BIN_DIR% mkdir %BIN_DIR%
+
+rem Build classpath from all jars in lib
+set CP=%LIB_DIR%\*
+
+rem Collect all java files
+(for /r %SRC_DIR% %%f in (*.java) do @echo %%f) > sources.txt
+
+rem Compile
+javac -d %BIN_DIR% -cp %CP% @sources.txt
+if errorlevel 1 exit /b 1
+
+rem Determine test classes
+set TESTS=
+for /f %%f in ('dir /b /s %SRC_DIR%\test\java\*Test.java') do (
+  set file=%%f
+  set class=!file:%SRC_DIR%\test\java\=!
+  set class=!class:.java=!
+  set class=!class:\=.!
+  set TESTS=!TESTS! !class!
+)
+
+java -cp "%BIN_DIR%;%CP%" org.junit.runner.JUnitCore %TESTS%
+if errorlevel 1 exit /b 1

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Directory for compiled classes
+BIN_DIR="bin"
+SRC_DIR="src"
+LIB_DIR="lib"
+
+# Ensure bin directory exists
+mkdir -p "$BIN_DIR"
+
+# Build classpath from jars in lib directory
+CP=$(echo "$LIB_DIR"/*.jar | tr ' ' ':')
+
+# Collect all Java source files
+find "$SRC_DIR" -name '*.java' > sources.txt
+
+# Compile
+javac -d "$BIN_DIR" -cp "$CP" @sources.txt
+
+# Determine test classes (all *Test.java under src/test/java)
+TESTS=$(find "$SRC_DIR"/test/java -name '*Test.java' | sed 's#^$SRC_DIR/test/java/##;s#\\.java$##;s#/#.#g')
+
+# Run tests
+java -cp "$BIN_DIR:$CP" org.junit.runner.JUnitCore $TESTS


### PR DESCRIPTION
## Summary
- add `run.sh` and `run.bat` scripts to compile sources with jars from `lib`
- scripts run JUnit tests and propagate failure codes

## Testing
- `javac -d bin -cp /opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar @all_sources.txt`
- `java -cp bin:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore de.czempin.nicnac16.simulator.DecoderTest`