### PR TITLE
Fix memory size constant in Processor

### DIFF
--- a/src/de/czempin/nicnac16/Processor.java
+++ b/src/de/czempin/nicnac16/Processor.java
@@ -1,7 +1,8 @@
 package de.czempin.nicnac16;
 
 public class Processor {
-	int mem[] = new int[65636];
+	private static final int MEMORY_SIZE = 65536;
+	int mem[] = new int[MEMORY_SIZE];
 	public int PC;
 	public int AC;
 


### PR DESCRIPTION
## Summary
- add `MEMORY_SIZE` constant in `Processor`
- allocate memory array using the constant

## Testing
- `javac -d bin -cp /opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar \`<br>  `src/de/czempin/nicnac16/*.java src/de/czempin/nicnac16/simulator/*.java \`<br>  `src/test/java/de/czempin/nicnac16/simulator/DecoderTest.java`
- `java -cp bin:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore de.czempin.nicnac16.simulator.DecoderTest`