### PR TITLE
Add setup, CI workflow and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Dependencies
+        run: ./setup.sh
+      - name: Generate Sources and Build
+        run: ./run.sh
+      - name: Lint Python
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+      - name: Run Tests
+        run: pytest -q

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Install build tools and Python packages
+sudo apt-get update
+sudo apt-get install -y build-essential cmake python3 python3-pip
+pip3 install --upgrade pip
+pip3 install pytest flake8
+
+# If using git submodules, initialize them
+if [ -f .gitmodules ]; then
+    git submodule update --init --recursive
+fi

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,10 @@
+import subprocess
+import os
+
+
+def test_simulator_runs():
+    bin_path = os.path.join('build', 'nicnac16_sim')
+    assert os.path.exists(bin_path), 'Simulator binary not built'
+    result = subprocess.run([bin_path], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert '===== END OF LINE =====' in result.stdout


### PR DESCRIPTION
## Summary
- add a `setup.sh` that installs dependencies and fetches submodules
- add a GitHub Actions workflow to run lint and smoke tests on pushes and PRs (ignoring docs)
- add a Python smoke test to run the built simulator

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
- `./build/nicnac16_sim`