### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake
+      - name: Generate sources
+        run: python3 scripts/generate_from_spec.py
+      - name: Lint
+        run: scripts/run_lint.sh
+      - name: Build
+        run: |
+          cmake -S . -B build
+          cmake --build build
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,13 @@ include_directories(
     generated_cpp 
 )
 
-file(GLOB SOURCES "cpp_src/*.cpp")
+file(GLOB SIM_SOURCES "cpp_src/processor.cpp")
 file(GLOB GENERATED_SOURCES "generated_cpp/*.cpp")
 
-add_executable(nicnac16_sim ${SOURCES} ${GENERATED_SOURCES})
+add_library(nicnac_lib ${SIM_SOURCES} ${GENERATED_SOURCES})
+
+add_executable(nicnac16_sim cpp_src/main.cpp)
+target_link_libraries(nicnac16_sim PRIVATE nicnac_lib)
+
+enable_testing()
+add_subdirectory(tests)

--- a/cpp_include/processor.hpp
+++ b/cpp_include/processor.hpp
@@ -25,5 +25,5 @@ private:
 
     // Helper method to print memory around a specific address
     // Made private as it's primarily a helper for readMemory and writeMemory logging
-    void printMemory(uint16_t address) const; 
+    void printMemory(uint16_t address) const;
 };

--- a/cpp_src/main.cpp
+++ b/cpp_src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
             std::cerr << "Error: Program Counter out of bounds!" << std::endl;
             break;
         }
-        
+
         word = p.readMemory(p.PC_);
 
         if (word == 0x7FFF) { // Special HALT value
@@ -54,14 +54,14 @@ int main(int argc, char* argv[]) {
         // The Decoder::decode function expects the full word, and it extracts the opcode.
         // So, we pass the full 'word'.
         try {
-            instruction_ptr = Decoder::decode(word); 
+            instruction_ptr = Decoder::decode(word);
         } catch (const std::runtime_error& e) {
             std::cerr << "Runtime Error during decode: " << e.what() << std::endl;
             std::cerr << "At PC: 0x" << std::hex << p.PC_ << ", word: 0x" << word << std::dec << std::endl;
             done = true; // Halt on unknown instruction
             continue;
         }
-        
+
 
         // Execute
         if (instruction_ptr) {
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
             // The base `Instruction::execute` is pure virtual.
             // Let's ensure the NOP instruction in generated code gets `p.incrementPC()`.
             // For this main loop, we call execute, and trust it does the right thing.
-            
+
             instruction_ptr->execute(word, p);
         } else {
             // This case should ideally not be reached if Decoder::decode throws on unknown opcodes.

--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+cmake -S . -B build_lint -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror"
+cmake --build build_lint

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(sim_tests simulator_basic.cpp)
+target_include_directories(sim_tests PRIVATE ${PROJECT_SOURCE_DIR}/cpp_include ${PROJECT_SOURCE_DIR}/generated_cpp ${PROJECT_SOURCE_DIR}/tests)
+target_link_libraries(sim_tests PRIVATE nicnac_lib)
+add_test(NAME simulator_basic COMMAND sim_tests)

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <functional>
+#include <vector>
+#include <string>
+#include <iostream>
+struct TestCase { std::string name; std::function<void()> func; };
+inline std::vector<TestCase>& getRegistry() { static std::vector<TestCase> r; return r; }
+struct Registrar { Registrar(const std::string& n,std::function<void()> f){ getRegistry().push_back({n,f}); } };
+#define TEST_CASE(name) static void test_##name(); static Registrar registrar_##name(#name,test_##name); static void test_##name()
+#define REQUIRE(cond) do { if(!(cond)){ std::cerr<<"Requirement failed: "#cond" at "<<__FILE__<<":"<<__LINE__<<std::endl; std::terminate(); } } while(0)
+inline int run_tests(){int failed=0;for(auto&tc:getRegistry()){try{tc.func();std::cout<<"[OK] "<<tc.name<<std::endl;}catch(...){std::cout<<"[FAIL] "<<tc.name<<std::endl;failed++;}}std::cout<<getRegistry().size()-failed<<"/"<<getRegistry().size()<<" tests passed."<<std::endl;return failed;}

--- a/tests/simulator_basic.cpp
+++ b/tests/simulator_basic.cpp
@@ -1,0 +1,31 @@
+#include "catch.hpp"
+#include "processor.hpp"
+#include "decoder.hpp"
+#include "instruction.hpp"
+
+TEST_CASE(basic_program) {
+    Processor p;
+    uint16_t next = 0;
+    p.writeMemory(next++, static_cast<uint16_t>((0b0100 << 12) | 0x0010));
+    p.writeMemory(next++, static_cast<uint16_t>((0b0110 << 12) | 0x0011));
+    p.writeMemory(next++, static_cast<uint16_t>((0b0101 << 12) | 0x0012));
+    p.writeMemory(next++, 0x7FFF);
+    p.writeMemory(0x0010, 1);
+    p.writeMemory(0x0011, 2);
+    bool done = false;
+    uint16_t word;
+    while (!done) {
+        word = p.readMemory(p.PC_);
+        if (word == 0x7FFF) {
+            done = true;
+        } else {
+            auto inst = Decoder::decode(word);
+            inst->execute(word, p);
+        }
+    }
+    REQUIRE(p.readMemory(0x0012) == 3);
+}
+
+int main(){
+    return run_tests();
+}


### PR DESCRIPTION
## Summary
- add minimal header-only test framework and sample simulator test
- build test executable with CMake
- add lint script using strict compiler flags
- set up GitHub Actions workflow to run lint and tests
- convert simulator sources into a library for reuse

## Testing
- `scripts/run_lint.sh`
- `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`