### PR TITLE
chore: ignore Python cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build/
 *.dylib
 *.gch
 *.pch
+
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore `__pycache__/` in `.gitignore`

## Testing
- `./run.sh`